### PR TITLE
Check for nodejs first to increase predictability

### DIFF
--- a/bin/main.sh
+++ b/bin/main.sh
@@ -10,7 +10,6 @@ if [ "$NODE" = "" ] ; then
 	if [ $? -eq 0 ] ; then NODE=node; fi
 fi
 
-
 if [ "$NODE" = "" ]; then
 	echo "Error: cannot start keybase; no version of node or nodejs found"
 	exit 2


### PR DESCRIPTION
On the debian based systems, if the other node app is installed it will break this script by making it think that nodejs is at node, but that's actually another app by the same name. By checking first if nodejs exists, you get around this problem as you never check for the less popular node app that doesn't work and nodejs is less likely to be a conflicting app.

I installed the not so nodejs version of node thinking I was getting nodejs and this caused a great deal of confusion and frustration until I got it straightened out. 
